### PR TITLE
[BUGFIX] Disable OPIC scoring plugin in Nutch config

### DIFF
--- a/conf/nutch-site.xml
+++ b/conf/nutch-site.xml
@@ -22,7 +22,7 @@
   
   <property>
     <name>plugin.includes</name>
-    <value>protocol-http|urlfilter-regex|parse-(html|tika)|index-(basic|anchor|static)|indexer-solr|scoring-opic|urlnormalizer-(pass|regex|basic)|language-identifier|urlmeta|typo3-(accessrootline|base|index-keywords|parse-keywords|sitehash|uid|endtime)</value>
+    <value>protocol-http|urlfilter-regex|parse-(html|tika)|index-(basic|anchor|static)|indexer-solr|urlnormalizer-(pass|regex|basic)|language-identifier|urlmeta|typo3-(accessrootline|base|index-keywords|parse-keywords|sitehash|uid|endtime)</value>
     <description>
       Regular expression naming plugin directory names to
       include.  Any plugin not matching this expression is excluded.


### PR DESCRIPTION
This prevents a too high scoring of Nutch results compared to
other (e.g. TYPO3) search results.

See also:
https://forge.typo3.org/issues/65658
