### PR TITLE
#160631 #161234: Dependency Update

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -46,8 +46,11 @@
 		<exec executable="git">
 			<arg value="clone"/>
 			<arg value="${nutch.scmsrc}"/>
+			<arg value="--tag"/>
+			<arg value="release-${nutch.version}"/>
 			<arg value="${build.nutch}"/>
 		</exec>
+		<!--
 		<exec executable="cd">
 			<arg value="${build.nutch}"/>
 		</exec>
@@ -55,6 +58,7 @@
 			<arg value="checkout"/>
 			<arg value="release-${nutch.version}"/>
 		</exec>
+		-->
 	</target>
 
 	<target name="compile-patch-nutch" depends="init, compile-checkout-src">

--- a/build.xml
+++ b/build.xml
@@ -46,7 +46,7 @@
 		<exec executable="git">
 			<arg value="clone"/>
 			<arg value="${nutch.scmsrc}"/>
-			<arg value="--tag"/>
+			<arg value="--branch"/>
 			<arg value="release-${nutch.version}"/>
 			<arg value="${build.nutch}"/>
 		</exec>

--- a/build.xml
+++ b/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <project name="${name}" default="dist">
 
-	<property file="${basedir}/default.properties" />
+	<property file="./default.properties" />
 
 	<!--	
 		Targets named nutch-* simply call Nutch's own ant targets
@@ -34,7 +34,7 @@
 	<!-- Building Nutch                                         -->
 	<!-- ====================================================== -->
 	<target name="compile" 
-		depends="nutch-compile, compile-typo3-plugins" 
+		depends="nutch-compile, compile-typo3-plugins"
 		description="--> build Nutch" 
 	/>
 
@@ -55,7 +55,7 @@
 			patchfile="${basedir}/patches/nutch-585-excludeNodes.patch"
 			dir="${build.nutch}"
 			strip="0"
-			failonerror="true"
+			failonerror="false"
 		/>
 	</target>
 

--- a/build.xml
+++ b/build.xml
@@ -50,15 +50,6 @@
 			<arg value="release-${nutch.version}"/>
 			<arg value="${build.nutch}"/>
 		</exec>
-		<!--
-		<exec executable="cd">
-			<arg value="${build.nutch}"/>
-		</exec>
-		<exec executable="git">
-			<arg value="checkout"/>
-			<arg value="release-${nutch.version}"/>
-		</exec>
-		-->
 	</target>
 
 	<target name="compile-patch-nutch" depends="init, compile-checkout-src">

--- a/build.xml
+++ b/build.xml
@@ -35,7 +35,7 @@
 	<!-- ====================================================== -->
 	<target name="compile" 
 		depends="nutch-compile, compile-typo3-plugins"
-		description="--> build Nutch" 
+		description="--> build Nutch"
 	/>
 
 	<target name="nutch-compile" depends="init, compile-checkout-src, compile-patch-nutch">
@@ -43,10 +43,17 @@
 	</target>
 
 	<target name="compile-checkout-src" depends="init">
-		<exec executable="svn">
-			<arg value="checkout"/>
-			<arg value="${nutch.scmsrc}/${nutch.version}"/>
+		<exec executable="git">
+			<arg value="clone"/>
+			<arg value="${nutch.scmsrc}"/>
 			<arg value="${build.nutch}"/>
+		</exec>
+		<exec executable="cd">
+			<arg value="${build.nutch}"/>
+		</exec>
+		<exec executable="git">
+			<arg value="checkout"/>
+			<arg value="release-${nutch.version}"/>
 		</exec>
 	</target>
 

--- a/build.xml
+++ b/build.xml
@@ -38,7 +38,7 @@
 		description="--> build Nutch"
 	/>
 
-	<target name="nutch-compile" depends="init, compile-checkout-src, compile-patch-nutch">
+	<target name="nutch-compile" depends="init, compile-checkout-src">
 		<ant dir="${build.nutch}" inheritAll="false"/>
 	</target>
 

--- a/build.xml
+++ b/build.xml
@@ -45,7 +45,7 @@
 	<target name="compile-checkout-src" depends="init">
 		<exec executable="svn">
 			<arg value="checkout"/>
-			<arg value="${nutch.scmsrc}/tags/release-${nutch.version}"/>
+			<arg value="${nutch.scmsrc}/${nutch.version}"/>
 			<arg value="${build.nutch}"/>
 		</exec>
 	</target>

--- a/conf/nutch-site.xml
+++ b/conf/nutch-site.xml
@@ -46,7 +46,7 @@
 
   <property>
     <name>typo3.baseUrl</name>
-    <value>https://solr-ddev-site.ddev.site</value>
+    <value>http://www.example.com</value>
     <description>
       URL to the website with the TYPO3 installation
     </description>
@@ -54,7 +54,7 @@
 
   <property>
     <name>typo3.api.key</name>
-    <value>f5b1c355a42e072309398ad345c1e8cfa2760dea</value>
+    <value></value>
     <description>
       Api Key for the SiteHash Api.
       Can be found in your TYPO3 installation backend in the Search Module at the bottom.

--- a/conf/nutch-site.xml
+++ b/conf/nutch-site.xml
@@ -46,7 +46,7 @@
 
   <property>
     <name>typo3.baseUrl</name>
-    <value>http://www.example.com</value>
+    <value>https://solr-ddev-site.ddev.site</value>
     <description>
       URL to the website with the TYPO3 installation
     </description>
@@ -54,7 +54,7 @@
 
   <property>
     <name>typo3.api.key</name>
-    <value></value>
+    <value>f5b1c355a42e072309398ad345c1e8cfa2760dea</value>
     <description>
       Api Key for the SiteHash Api.
       Can be found in your TYPO3 installation backend in the Search Module at the bottom.

--- a/default.properties
+++ b/default.properties
@@ -4,7 +4,7 @@ version = 2.1.1
 final.name = ${name}-${version}
 
 nutch.version = 1.19
-nutch.scmsrc = https://svn.apache.org/repos/asf/nutch
+nutch.scmsrc = https://dlcdn.apache.org/nutch/
 
 basedir = ./
 plugins.dir = ${basedir}/src/plugin

--- a/default.properties
+++ b/default.properties
@@ -4,7 +4,7 @@ version = 2.1.1
 final.name = ${name}-${version}
 
 nutch.version = 1.19
-nutch.scmsrc = https://dlcdn.apache.org/nutch/
+nutch.scmsrc = https://github.com/apache/nutch.git
 
 basedir = ./
 plugins.dir = ${basedir}/src/plugin

--- a/default.properties
+++ b/default.properties
@@ -3,8 +3,8 @@ name = apache-nutch-for-typo3
 version = 2.1.1
 final.name = ${name}-${version}
 
-nutch.version = 1.8
-nutch.scmsrc = http://svn.apache.org/repos/asf/nutch
+nutch.version = 1.19
+nutch.scmsrc = https://svn.apache.org/repos/asf/nutch
 
 basedir = ./
 plugins.dir = ${basedir}/src/plugin

--- a/pom.xml
+++ b/pom.xml
@@ -16,29 +16,29 @@
 		<dependency>
 			<groupId>org.apache.nutch</groupId>
 			<artifactId>nutch</artifactId>
-			<version>1.18</version>
+			<version>1.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.5.5</version>
+			<version>2.0.6</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
-			<artifactId>hadoop-core</artifactId>
-			<version>0.20.2</version>
+			<artifactId>hadoop-client</artifactId>
+			<version>3.3.1</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-core-asl</artifactId>
-			<version>1.9.3</version>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>2.13.4</version>
 		</dependency>
 		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-mapper-asl</artifactId>
-			<version>1.9.3</version>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.13.4.2</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
Fix for [#160631](https://redmine.dkd.de/issues/160631) & [161234](https://redmine.dkd.de/issues/161234)

Dependency Updates:
* Nutch from 1.8 to 1.19
* slf4j-log4j12 from 1.5.5 to 2.0.6
* hadoop-core-0.20.2 switched to hadoop-client-3.3.1
* jackson-core-asl-1.9.3 switched to jackson-core-2.13.4
* jackson-mapper-asl-1.9.3 switched to jackson-databind-2.13.4.2

Further changes:
* Removed ant target `compile-patch-nutch` from build process
* Pulled nutch plugin from git instead of obsolete svn repo